### PR TITLE
Fixed some links and removed auto-migrated flag

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,10 +3,7 @@ layout: col-sidebar
 title: OWASP Sacramento
 tags: past-tag
 level: 0
-
 region: North America
-
-auto-migrated: 1
 ---
 
 ## Welcome
@@ -14,41 +11,23 @@ Welcome to the Sacramento OWASP. We are a group of Security, Networking, Technol
 
 ## Upcoming Event:
 
-[March Meetup](https://www.meetup.com/OWASP-Sacramento-Chapter/events/269447049/) @ Google Hangouts.
+[March Meetup](https://www.meetup.com/OWASP-Sacramento-Chapter/events/269447049/){:target="_blank"} @ Google Hangouts.
 
 ## Events
-The best way to find our events is to look on [Meetup.com](https://www.meetup.com/OWASP-Sacramento-Chapter/). Be sure to join so that you can be notified of new events.
+The best way to find our events is to look on [Meetup.com](https://www.meetup.com/OWASP-Sacramento-Chapter/){:target="_blank"}. Be sure to join so that you can be notified of new events.
 
 ## Contact
 The best way to get in touch is Slack.
 
-1. [Go to this link](http://owaspslack.com)
- (not a typo).
+1. Go to [this link](https://owasp-slack.herokuapp.com/){:target="_blank"}.
 2. Register with your e-mail address.
 3. When in the Slack, find our channel in the channel list, or simply type: `/join #chapter-sacramento`
 
 
-
 ## Participation
-The Open Web Application Security Project (OWASP) is a nonprofit foundation that
-works to improve the security of software. All of our projects, tools,
-documents, forums, and chapters are free and open to anyone interested in
-improving application security.
+The Open Web Application Security Project (OWASP) is a nonprofit foundation that works to improve the security of software. All of our projects, tools, documents, forums, and chapters are free and open to anyone interested in improving application security.
 
-Chapters are led by local leaders in accordance with the
-[Chapter Leader Handbook](/www-policy/rules-of-procedure/chapter-handbook).
-Financial contributions should only be made online using the authorized online
-donation button. To be a SPEAKER at ANY OWASP Chapter in the world simply review
-the [speaker agreement](/www-policy/speaker-agreement) and then contact the
-local chapter leader with details of what OWASP Project, independent research,
-or related software security topic you would like to present.
+Chapters are led by local leaders in accordance with the [Chapter Leader Handbook](/www-policy/rules-of-procedure/chapter-handbook). Financial contributions should only be made online using the authorized online donation button. To be a SPEAKER at ANY OWASP Chapter in the world simply review the [speaker agreement](/www-policy/speaker-agreement) and then contact the
+local chapter leader with details of what OWASP Project, independent research, or related software security topic you would like to present.
 
-Everyone is welcome and encouraged to participate in our [Projects](/projects),
-[Local Chapters](/chapters), [Events](/events),
-[Online Groups](https://groups.google.com/a/owasp.com/){:target='_blank'}, and
-on Slack @[#chapter-sacramento](https://owasp.slack.com/){:target='_blank'}. We
-especially encourage diversity in all our initiatives. OWASP is a fantastic
-place to learn about application security, to network, and even to build your
-reputation as an expert. We also encourage you to be
-[become a member](/membership) or consider a [donation](/donate) to support our
-ongoing work.
+Everyone is welcome and encouraged to participate in our [Projects](/projects), [Local Chapters](/chapters), [Events](/events), [Online Groups](https://groups.google.com/a/owasp.com/){:target='_blank'}, and on Slack @[#chapter-sacramento](https://owasp.slack.com/app_redirect?channel=chapter-sacramento){:target='_blank'}. We especially encourage diversity in all our initiatives. OWASP is a fantastic place to learn about application security, to network, and even to build your reputation as an expert. We also encourage you to be [become a member](/membership) or consider a [donation](/donate) to support our ongoing work.


### PR DESCRIPTION
Fixed various links, including the OWASP Slack registration site (previous link no longer works -- "expired invite"), and added auto-redirection to Sacramento channel. Removed auto-migrated flag, so that the big yellow message at the top no longer appears.